### PR TITLE
Updates for cardano node 8.9.3

### DIFF
--- a/dockerfiles/armada-cn-arm64.dockerfile
+++ b/dockerfiles/armada-cn-arm64.dockerfile
@@ -9,8 +9,11 @@ RUN apt-get update \
 WORKDIR /cardano-node
 
 ## Download latest cardano-cli, cardano-node tx-submit-service version static build
-RUN wget -O cardano-8_9_1-aarch64-static-musl-ghc_964.zip https://github.com/armada-alliance/cardano-node-binaries/blob/main/static-binaries/cardano-8_9_1-aarch64-static-musl-ghc_964.zip?raw=true \
-    && unzip cardano-8_9_1-aarch64-static-musl-ghc_964.zip
+RUN wget -O cardano-8_9_3-aarch64-static-musl-ghc_964.tar.zst https://github.com/armada-alliance/cardano-node-binaries/blob/main/static-binaries/cardano-8_9_3-aarch64-static-musl-ghc_964.tar.zst?raw=true \
+    && apt-get install -y zstd \
+    && zstd -d cardano-8_9_3-aarch64-static-musl-ghc_964.tar.zst \
+    && tar -xvf cardano-8_9_3-aarch64-static-musl-ghc_964.tar
+
 RUN wget -O cardano-submit-api-3_2_2.zip https://github.com/armada-alliance/cardano-node-binaries/blob/main/static-binaries/cardano-submit-api/cardano-submit-api-3_2_2.zip?raw=true \
     && unzip cardano-submit-api-3_2_2.zip
 
@@ -42,7 +45,7 @@ WORKDIR /home/cardano/pi-pool/.keys
 WORKDIR /home/cardano/git
 WORKDIR /home/cardano/tmp
 
-COPY --from=builder /cardano-node/cardano-8_9_1-aarch64-static-musl-ghc_964/* /home/cardano/.local/bin/
+COPY --from=builder /cardano-node/cardano-8_9_3-aarch64-static-musl-ghc_964/* /home/cardano/.local/bin/
 COPY --from=builder /cardano-node/cardano-submit-api /home/cardano/.local/bin/
 
 WORKDIR /home/cardano/pi-pool/scripts
@@ -66,4 +69,3 @@ COPY /files/tx-submit-service /home/cardano/.local/bin
 COPY /files/run.sh /
 
 CMD ["/run.sh"]
-##ENTRYPOINT ["bash", "-c"]

--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -3,7 +3,7 @@
 set -x
 
 ## Configuration paramenters
-CNVERSION="8.9.1"        			## Version of the cardano-node. (Note: Must match the version downloaded in the dockerbuild file)
+CNVERSION="8.9.3"        			## Version of the cardano-node. (Note: Must match the version downloaded in the dockerbuild file)
 CNCONT_NAME="armadaalliance"			## Define the name of your docker container
 
 

--- a/node/run-node.sh
+++ b/node/run-node.sh
@@ -4,7 +4,7 @@ set -x
 
 ##Configuration for relay and block producing node
 CNIMAGENAME="armadaalliance/armada-cn"                           ## Name of the Cardano docker image
-CNVERSION="8.9.1"                                                ## Version of the cardano-node. It must match with the version of the docker image
+CNVERSION="8.9.3"                                                ## Version of the cardano-node. It must match with the version of the docker image
 CNNETWORK="preprod"                                              ## Use "mainnet" if connecting node to the mainnet
 CNMODE="relay"                                                   ## Use "bp" if you configure the node as block production node
 CNPORT="3001"                                                    ## Define the port of the node


### PR DESCRIPTION
Updates for 8.9.3 and handling the static files was .zip is now .tar.zst per repo updates.