### PR TITLE
Use cardano-node 9.1.1 static binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Edit the configuration section according to your setup.
 ```bash
 ##Configuration for relay and block producing node
 CNIMAGENAME="armada/armada-cn"                                   ## Name of the Cardano docker image
-CNVERSION="8.9.1"                                               ## Version of the cardano-node. It must match with the version of the docker i>
+CNVERSION="9.1.1"                                               ## Version of the cardano-node. It must match with the version of the docker i>
 CNNETWORK="testnet"                                              ## Use "mainnet" if connecting node to the mainnet
 CNMODE="relay"                                                   ## Use "bp" if you configure the node as block production node
 CNPORT="3001"                                                    ## Define the port of the node

--- a/dockerfiles/armada-cn-arm64.dockerfile
+++ b/dockerfiles/armada-cn-arm64.dockerfile
@@ -1,18 +1,18 @@
-FROM ubuntu:20.04 as builder
+FROM ubuntu:22.04 as builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get upgrade -y zip wget automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev \
-    zlib1g-dev make g++ tmux git jq curl libncursesw5 libtool autoconf llvm libnuma-dev
+    zlib1g-dev make g++ tmux git jq curl libncursesw5 libtool autoconf llvm libnuma-dev xz-utils zstd
 
 WORKDIR /cardano-node
 
 ## Download latest cardano-cli, cardano-node tx-submit-service version static build
-RUN wget -O cardano-8_9_1-aarch64-static-musl-ghc_964.zip https://github.com/armada-alliance/cardano-node-binaries/blob/main/static-binaries/cardano-8_9_1-aarch64-static-musl-ghc_964.zip?raw=true \
-    && unzip cardano-8_9_1-aarch64-static-musl-ghc_964.zip
-RUN wget -O cardano-submit-api-3_2_2.zip https://github.com/armada-alliance/cardano-node-binaries/blob/main/static-binaries/cardano-submit-api/cardano-submit-api-3_2_2.zip?raw=true \
-    && unzip cardano-submit-api-3_2_2.zip
+RUN wget -O cardano-9_1_1-aarch64-static-musl-ghc_966.tar.zst \
+https://github.com/armada-alliance/cardano-node-binaries/blob/main/static-binaries/cardano-9_1_1-aarch64-static-musl-ghc_966.tar.zst?raw=true \
+&& tar -I zstd -xvf cardano-9_1_1-aarch64-static-musl-ghc_966.tar.zst
+
 
 ## Install libsodium (needed for ScheduledBlocks.py)
 WORKDIR /build/libsodium
@@ -21,7 +21,7 @@ RUN cd libsodium && \
     git checkout 66f017f1 && \
     ./autogen.sh && ./configure && make && make install
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -42,8 +42,8 @@ WORKDIR /home/cardano/pi-pool/.keys
 WORKDIR /home/cardano/git
 WORKDIR /home/cardano/tmp
 
-COPY --from=builder /cardano-node/cardano-8_9_1-aarch64-static-musl-ghc_964/* /home/cardano/.local/bin/
-COPY --from=builder /cardano-node/cardano-submit-api /home/cardano/.local/bin/
+COPY --from=builder /cardano-node/cardano-9_1_1-aarch64-static-musl-ghc_966/* /home/cardano/.local/bin/
+
 
 WORKDIR /home/cardano/pi-pool/scripts
 COPY /files/run.sh /home/cardano/pi-pool/scripts

--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -3,7 +3,7 @@
 set -x
 
 ## Configuration paramenters
-CNVERSION="8.9.1"        			## Version of the cardano-node. (Note: Must match the version downloaded in the dockerbuild file)
+CNVERSION="9.1.1"           			## Version of the cardano-node. (Note: Must match the version downloaded in the dockerbuild file)
 CNCONT_NAME="armadaalliance"			## Define the name of your docker container
 
 

--- a/node/run-node.sh
+++ b/node/run-node.sh
@@ -4,7 +4,7 @@ set -x
 
 ##Configuration for relay and block producing node
 CNIMAGENAME="armadaalliance/armada-cn"                           ## Name of the Cardano docker image
-CNVERSION="8.9.1"                                                ## Version of the cardano-node. It must match with the version of the docker image
+CNVERSION="9.1.1"                                                ## Version of the cardano-node. It must match with the version of the docker image
 CNNETWORK="preprod"                                              ## Use "mainnet" if connecting node to the mainnet
 CNMODE="relay"                                                   ## Use "bp" if you configure the node as block production node
 CNPORT="3001"                                                    ## Define the port of the node


### PR DESCRIPTION
Updated dockerfile to use Ubuntu 22.04 and cardano-node 9.1.1. (since i need to use this specific version right now)
Maybe use tags for different cardano-node versions? Using the latest cardano-node might not always be desirable.

